### PR TITLE
Update extract.py to create the hst-whitelist.txt

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -74,8 +74,7 @@ def create_folders(output_folder, folder_list):
 
 # create hst-whitelist with all the folders being created
 def create_whitelist(output_folder, folder_list):
-    folder_list_suffixed = list(map(lambda folder: "%s/" % folder, folder_list))
-    file_contents = HST_WHITELIST_PREAMBLE + "\n".join(folder_list_suffixed)
+    file_contents = HST_WHITELIST_PREAMBLE + "/\n".join(folder_list + [""])
 
     file_name = "%s/%s" % (output_folder, HST_WHITELIST_FILE_NAME)
     with open(file_name, 'w') as f:

--- a/extract.py
+++ b/extract.py
@@ -11,7 +11,6 @@ import sys
 import urlparse
 
 FOLDERS_TO_CREATE = ['css', 'fonts', 'icons', 'images', 'js', 'other']
-HST_WHITELIST_FILE_NAME = "hst-whitelist.txt"
 HEADER = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/65.0.3325.181 Safari/537.36"
@@ -23,6 +22,33 @@ WEBFILES_START_TAG_SEARCHREPLACE = "===webfiles_start_tag==="
 WEBFILES_END_TAG_SEARCHREPLACE = "===webfiles_end_tag==="
 WEBFILES_START_TAG = "<@hst.webfile path=\""
 WEBFILES_END_TAG = "\"/>"
+
+HST_WHITELIST_FILE_NAME = "hst-whitelist.txt"
+HST_WHITELIST_PREAMBLE = """\
+##########################################################################
+#                                                                        #
+#   This file must contain all files and folders that                    #
+#   most be publicly available over http. Typically folders              #
+#   that contain server side scripts, such a freemarker                  #
+#   templates, should not be added as they in general should             #
+#   not be publicly available.                                           #
+#                                                                        #
+#   The whitelisting is *relative* to the 'web file bundle root'         #
+#   which is the folder in which this hst-whitelist.txt file is          #
+#   located.                                                             #
+#                                                                        #
+#   Examples assuming the web file bundle root is 'site':                #
+#                                                                        #
+#   css/       : whitelists all descendant web files below 'site/css/'   #
+#   common.js  : whitelists the file 'site/common.js'                    #
+#                                                                        #
+#   Note that the whitelisting is 'starts-with' based, thus for          #
+#   example whitelisting 'css' without '/' behind it, whitelists all     #
+#   files and folders that start with 'css'                              #
+#                                                                        #
+##########################################################################
+
+"""
 
 # initiate logger
 logging.basicConfig()
@@ -48,33 +74,8 @@ def create_folders(output_folder, folder_list):
 
 # create hst-whitelist with all the folders being created
 def create_whitelist(output_folder, folder_list):
-    file_contents = """
-##########################################################################
-#                                                                        #
-#   This file must contain all files and folders that                    #
-#   most be publicly available over http. Typically folders              #
-#   that contain server side scripts, such a freemarker                  #
-#   templates, should not be added as they in general should             #
-#   not be publicly available.                                           #
-#                                                                        #
-#   The whitelisting is *relative* to the 'web file bundle root'         #
-#   which is the folder in which this hst-whitelist.txt file is          #
-#   located.                                                             #
-#                                                                        #
-#   Examples assuming the web file bundle root is 'site':                #
-#                                                                        #
-#   css/       : whitelists all descendant web files below 'site/css/'   #
-#   common.js  : whitelists the file 'site/common.js'                    #
-#                                                                        #
-#   Note that the whitelisting is 'starts-with' based, thus for          #
-#   example whitelisting 'css' without '/' behind it, whitelists all     #
-#   files and folders that start with 'css'                              #
-#                                                                        #
-##########################################################################
-
-"""
     folder_list_suffixed = list(map(lambda folder: "%s/" % folder, folder_list))
-    file_contents += "\n".join(folder_list_suffixed)
+    file_contents = HST_WHITELIST_PREAMBLE + "\n".join(folder_list_suffixed)
 
     file_name = "%s/%s" % (output_folder, HST_WHITELIST_FILE_NAME)
     with open(file_name, 'w') as f:

--- a/extract.py
+++ b/extract.py
@@ -11,6 +11,7 @@ import sys
 import urlparse
 
 FOLDERS_TO_CREATE = ['css', 'fonts', 'icons', 'images', 'js', 'other']
+HST_WHITELIST_FILE_NAME = "hst-whitelist.txt"
 HEADER = {
     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/65.0.3325.181 Safari/537.36"
@@ -43,6 +44,41 @@ def create_folders(output_folder, folder_list):
         folder_path = "%s/%s" % (output_folder, folder)
         if not os.path.exists(folder_path):
             os.makedirs(folder_path)
+
+
+# create hst-whitelist with all the folders being created
+def create_whitelist(output_folder, folder_list):
+    file_contents = """
+##########################################################################
+#                                                                        #
+#   This file must contain all files and folders that                    #
+#   most be publicly available over http. Typically folders              #
+#   that contain server side scripts, such a freemarker                  #
+#   templates, should not be added as they in general should             #
+#   not be publicly available.                                           #
+#                                                                        #
+#   The whitelisting is *relative* to the 'web file bundle root'         #
+#   which is the folder in which this hst-whitelist.txt file is          #
+#   located.                                                             #
+#                                                                        #
+#   Examples assuming the web file bundle root is 'site':                #
+#                                                                        #
+#   css/       : whitelists all descendant web files below 'site/css/'   #
+#   common.js  : whitelists the file 'site/common.js'                    #
+#                                                                        #
+#   Note that the whitelisting is 'starts-with' based, thus for          #
+#   example whitelisting 'css' without '/' behind it, whitelists all     #
+#   files and folders that start with 'css'                              #
+#                                                                        #
+##########################################################################
+
+"""
+    folder_list_suffixed = list(map(lambda folder: "%s/" % folder, folder_list))
+    file_contents += "\n".join(folder_list_suffixed)
+
+    file_name = "%s/%s" % (output_folder, HST_WHITELIST_FILE_NAME)
+    with open(file_name, 'w') as f:
+        f.write(file_contents)
 
 
 # download resource for URL, raise error if 404 or other error is returned
@@ -217,6 +253,9 @@ def main(url, save_folder):
         if root is not None:
             # prepare folders
             create_folders(save_folder, FOLDERS_TO_CREATE)
+
+            # whitelist folders
+            create_whitelist(save_folder, FOLDERS_TO_CREATE)
 
             # list containing relative paths to CSS files, for retrieving web resources within these files later on
             css_files = []


### PR DESCRIPTION
Since this tool creates folders which are not listed in the default `hst-whitelist.txt`, following the instructions resulted in a site with several resources which were blocked from public access.  This creates a new `hst-whitelist.txt` which includes all folders.

I've included the file header, since it may provide important information when users are making future changes to the whitelist.  I have mixed feelings about including it as a multiline string in the python source vs creating a new project file which could be copied and amended.  I went with the former, because I am making this change on Github.com and can only edit one file at a time. 
`¯\_(ツ)_/¯`

Edit: moved the file header/preamble to a constant (called constants in python?) for slightly cleaner code.